### PR TITLE
Use displayed values

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -17,7 +17,7 @@ function convetSeletedRangeToMarkdown() {
     if (i > 0) {
       md += "\n\n";
     }
-    const valuesList = range.getValues();
+    const valuesList = range.getDisplayValues();
     valuesList.forEach((vl, i) => {
       let row = '|';
       if (i === 1) {


### PR DESCRIPTION
The method getValues could give us unexpected texts when the data is date. For example, the date data "2022/11/15" is returned as "Mon Nov 14 2022 10:00:00 GMT-0500 (アメリカ東部標準時)". Using getDisplayValues instead of getValues prevent this.